### PR TITLE
Avoid message "Error ignored"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,7 +296,7 @@ endif
 %: PARAMS =
 %:
 	@$(if $(and $(TOOL),$<),echo "building $@ from $< with pattern rule for $(TOOL)",$(MAKE) -R -f /dev/null $@)
-	-ocrd workspace remove-group -r $@ 2>/dev/null
+	ocrd workspace remove-group -r $@ 2>/dev/null || true
 	$(file > $@.json, { $(PARAMS) })
 	$(if $(GPU),$(gputoolrecipe),$(toolrecipe))
 


### PR DESCRIPTION
This kind of messages is confusing for the user, so avoid it:

    ocrd workspace remove-group -r OCR-D-OCR-TESS-gt4histocr-BINPAGE-sauvola-CLIP-RESEG-DEWARP 2>/dev/null
    make: [Makefile:299: OCR-D-OCR-TESS-gt4histocr-BINPAGE-sauvola-CLIP-RESEG-DEWARP] Fehler 1 (ignoriert)

Signed-off-by: Stefan Weil <sw@weilnetz.de>