### PR TITLE
ocrd-make -C to cleanup *.mk; link/copy only unless exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ CONFIGNAME := $(basename $(notdir $(CONFIGURATION)))
 
 WORKSPACES := $(patsubst %/mets.xml,%,$(wildcard */data/mets.xml */mets.xml))
 
-ifeq ($(filter help info repair deps-ubuntu install uninstall %.mk,$(MAKECMDGOALS)),)
+ifeq ($(filter help cleanup info repair deps-ubuntu install uninstall %.mk,$(MAKECMDGOALS)),)
 ifeq ($(notdir $(MAKEFILE_LIST)),Makefile)
 $(error Did you forget to select a workflow configuration makefile?)
 else
@@ -71,6 +71,7 @@ help:
 	@echo
 	@echo "  Targets (general):"
 	@echo "  * help (this message)"
+	@echo "  * cleanup (remove symlinked/copied Makefiles)"
 	@echo "  * deps-ubuntu (install extra system packages needed here, beyond ocrd and processors)"
 	@echo "  * install (copy 'ocrd-make' script and configuration makefiles to"
 	@echo "  *          VIRTUAL_ENV=$(VIRTUAL_ENV))"
@@ -110,6 +111,9 @@ install:
 uninstall:
 	$(RM) $(BINDIR)/ocrd-make
 	$(RM) -r $(SHAREDIR)
+
+cleanup:
+	find $(SHAREDIR) \( -name 'Makefile' -or -name '*.mk' \) -exec basename {} \; |xargs rm -v
 
 .PHONY: deps-ubuntu install uninstall
 

--- a/ocrd-make
+++ b/ocrd-make
@@ -24,10 +24,9 @@ function process {
         for f in *.mk Makefile;do
             local src="$SHAREDIR/$f"
             local dst="$CURDIR/$f"
-            if [[ -e "$dst" ]];then
-                continue
+            if [[ ! -e "$dst" || "$src" -nt "$dst" ]];then
+                ln -s "$src" "$dst" 2>/dev/null || cp -f "$src" "$dst"
             fi
-            ln -s "$src" "$dst" 2>/dev/null || cp -f "$src" "$dst"
         done
         make -C "$CURDIR" "$@"
     )

--- a/ocrd-make
+++ b/ocrd-make
@@ -34,7 +34,7 @@ function process {
 }
 
 case ${1:--h} in
-    -C|-[-]cleanup|cleanup)
+    -c|-[-]cleanup|cleanup)
         process --no-print-directory cleanup
         exit
         ;;

--- a/ocrd-make
+++ b/ocrd-make
@@ -21,13 +21,23 @@ function process {
         # we want to have a fall-back for FS without symlink support
         # or when some makefile already exists (perhaps with customization)
         # but unfortunately, `cp -u` has strange semantics w.r.t. retvalue
-        ln -t "$CURDIR" -s "$SHAREDIR"/{*.mk,Makefile} 2>/dev/null || cp -fu "$SHAREDIR"/{*.mk,Makefile} "$CURDIR"
+        for f in *.mk Makefile;do
+            local src="$SHAREDIR/$f"
+            local dst="$CURDIR/$f"
+            if [[ -e "$dst" ]];then
+                continue
+            fi
+            ln -s "$src" "$dst" 2>/dev/null || cp -f "$src" "$dst"
+        done
         make -C "$CURDIR" "$@"
     )
 }
 
-
 case ${1:--h} in
+    -C|-[-]cleanup|cleanup)
+        process --no-print-directory cleanup
+        exit
+        ;;
     -h|-[-]help|help)
         cat <<EOF
   (This will merely delegate to \`make\` on the current working directory "$PWD"


### PR DESCRIPTION
Two changes:

  * `ocrd-make -c|-cleanup|-cleanup|cleanup` to remove the Makefiles linked/copies to `$PWD`
  * Add a guard against overwriting existing files. Without such a check, calling the script twice (e.g. to see the `--help`) will result in the `ln -s` failiing and `cp -f` subsequently complaining that source and origin of file to copy are identical