### PR TITLE
use pyrnn.gz models instead of pyrnn

### DIFF
--- a/crop-anyocr-binarize-page-olena-sauvola-denoise-ocropy-deskew-page-ocropy-segment-tesseract-ocropy-dewarp-ocr-ocropy-tesseract.mk
+++ b/crop-anyocr-binarize-page-olena-sauvola-denoise-ocropy-deskew-page-ocropy-segment-tesseract-ocropy-dewarp-ocr-ocropy-tesseract.mk
@@ -111,8 +111,8 @@ OCR8 = OCR-D-OCR-CALA-gt4histocr-$(DEW:OCR-D-%=%)
 $(OCR1) $(OCR2) $(OCR3) $(OCR4) $(OCR5) $(OCR6) $(OCR7) $(OCR8): $(DEW)
 
 $(OCR1) $(OCR2): TOOL = ocrd-cis-ocropy-recognize
-$(OCR1): PARAMS = "textequiv_level": "glyph", "model": "fraktur.pyrnn"
-$(OCR2): PARAMS = "textequiv_level": "glyph", "model": "fraktur-jze.pyrnn"
+$(OCR1): PARAMS = "textequiv_level": "glyph", "model": "fraktur.pyrnn.gz"
+$(OCR2): PARAMS = "textequiv_level": "glyph", "model": "fraktur-jze.pyrnn.gz"
 
 $(OCR3) $(OCR4) $(OCR5) $(OCR6) $(OCR7): TOOL = ocrd-tesserocr-recognize
 $(OCR3): PARAMS = "textequiv_level" : "glyph", "overwrite_words": true, "model" : "script/Fraktur"

--- a/gt-binarize-page-olena-sauvola-clip-resegment-dewarp-ocr-ocropy-tesseract.mk
+++ b/gt-binarize-page-olena-sauvola-clip-resegment-dewarp-ocr-ocropy-tesseract.mk
@@ -60,8 +60,8 @@ OCR8 = $(DEW:$(INPUT)-%=OCR-D-OCR-CALA-gt4histocr-%)
 $(OCR1) $(OCR2) $(OCR3) $(OCR4) $(OCR5) $(OCR6) $(OCR7) $(OCR8): $(DEW)
 
 $(OCR1) $(OCR2): TOOL = ocrd-cis-ocropy-recognize
-$(OCR1): PARAMS = "textequiv_level": "glyph", "model": "fraktur.pyrnn"
-$(OCR2): PARAMS = "textequiv_level": "glyph", "model": "fraktur-jze.pyrnn"
+$(OCR1): PARAMS = "textequiv_level": "glyph", "model": "fraktur.pyrnn.gz"
+$(OCR2): PARAMS = "textequiv_level": "glyph", "model": "fraktur-jze.pyrnn.gz"
 
 $(OCR3) $(OCR4) $(OCR5) $(OCR6) $(OCR7): TOOL = ocrd-tesserocr-recognize
 $(OCR3): PARAMS = "textequiv_level" : "glyph", "overwrite_words": true, "model" : "script/Fraktur"

--- a/gt-binarize-page-olena-sauvola-denoise-ocropy-clip-resegment-dewarp-ocr-ocropy-tesseract.mk
+++ b/gt-binarize-page-olena-sauvola-denoise-ocropy-clip-resegment-dewarp-ocr-ocropy-tesseract.mk
@@ -66,8 +66,8 @@ OCR8 = $(DEW:$(INPUT)-%=OCR-D-OCR-CALA-gt4histocr-%)
 $(OCR1) $(OCR2) $(OCR3) $(OCR4) $(OCR5) $(OCR6) $(OCR7) $(OCR8): $(DEW)
 
 $(OCR1) $(OCR2): TOOL = ocrd-cis-ocropy-recognize
-$(OCR1): PARAMS = "textequiv_level": "glyph", "model": "fraktur.pyrnn"
-$(OCR2): PARAMS = "textequiv_level": "glyph", "model": "fraktur-jze.pyrnn"
+$(OCR1): PARAMS = "textequiv_level": "glyph", "model": "fraktur.pyrnn.gz"
+$(OCR2): PARAMS = "textequiv_level": "glyph", "model": "fraktur-jze.pyrnn.gz"
 
 $(OCR3) $(OCR4) $(OCR5) $(OCR6) $(OCR7): TOOL = ocrd-tesserocr-recognize
 $(OCR3): PARAMS = "textequiv_level" : "glyph", "overwrite_words": true, "model" : "script/Fraktur"

--- a/gt-binarize-page-olena-sauvola-denoise-ocropy-deskew-page-ocropy-clip-deskew-region-tesseract-resegment-dewarp-ocr-ocropy-tesseract-extract-lines.mk
+++ b/gt-binarize-page-olena-sauvola-denoise-ocropy-deskew-page-ocropy-clip-deskew-region-tesseract-resegment-dewarp-ocr-ocropy-tesseract-extract-lines.mk
@@ -91,8 +91,8 @@ OCR8 = $(DEW:$(INPUT)-%=OCR-D-OCR-CALA-gt4histocr-%)
 $(OCR1) $(OCR2) $(OCR3) $(OCR4) $(OCR5) $(OCR6) $(OCR7) $(OCR8): $(DEW)
 
 $(OCR1) $(OCR2): TOOL = ocrd-cis-ocropy-recognize
-$(OCR1): PARAMS = "textequiv_level": "glyph", "model": "fraktur.pyrnn"
-$(OCR2): PARAMS = "textequiv_level": "glyph", "model": "fraktur-jze.pyrnn"
+$(OCR1): PARAMS = "textequiv_level": "glyph", "model": "fraktur.pyrnn.gz"
+$(OCR2): PARAMS = "textequiv_level": "glyph", "model": "fraktur-jze.pyrnn.gz"
 
 $(OCR3) $(OCR4) $(OCR5) $(OCR6) $(OCR7): TOOL = ocrd-tesserocr-recognize
 $(OCR3): PARAMS = "textequiv_level" : "glyph", "overwrite_words": true, "model" : "script/Fraktur"

--- a/gt-binarize-page-olena-sauvola-denoise-ocropy-deskew-page-ocropy-clip-deskew-region-tesseract-resegment-dewarp-ocr-ocropy-tesseract.mk
+++ b/gt-binarize-page-olena-sauvola-denoise-ocropy-deskew-page-ocropy-clip-deskew-region-tesseract-resegment-dewarp-ocr-ocropy-tesseract.mk
@@ -90,8 +90,8 @@ OCR8 = $(DEW:$(INPUT)-%=OCR-D-OCR-CALA-gt4histocr-%)
 $(OCR1) $(OCR2) $(OCR3) $(OCR4) $(OCR5) $(OCR6) $(OCR7) $(OCR8): $(DEW)
 
 $(OCR1) $(OCR2): TOOL = ocrd-cis-ocropy-recognize
-$(OCR1): PARAMS = "textequiv_level": "glyph", "model": "fraktur.pyrnn"
-$(OCR2): PARAMS = "textequiv_level": "glyph", "model": "fraktur-jze.pyrnn"
+$(OCR1): PARAMS = "textequiv_level": "glyph", "model": "fraktur.pyrnn.gz"
+$(OCR2): PARAMS = "textequiv_level": "glyph", "model": "fraktur-jze.pyrnn.gz"
 
 $(OCR3) $(OCR4) $(OCR5) $(OCR6) $(OCR7): TOOL = ocrd-tesserocr-recognize
 $(OCR3): PARAMS = "textequiv_level" : "glyph", "overwrite_words": true, "model" : "script/Fraktur"

--- a/gt-binarize-page-olena-sauvola-denoise-ocropy-deskew-page-ocropy-clip-resegment-dewarp-ocr-ocropy-tesseract.mk
+++ b/gt-binarize-page-olena-sauvola-denoise-ocropy-deskew-page-ocropy-clip-resegment-dewarp-ocr-ocropy-tesseract.mk
@@ -78,8 +78,8 @@ OCR8 = $(DEW:$(INPUT)-%=OCR-D-OCR-CALA-gt4histocr-%)
 $(OCR1) $(OCR2) $(OCR3) $(OCR4) $(OCR5) $(OCR6) $(OCR7) $(OCR8): $(DEW)
 
 $(OCR1) $(OCR2): TOOL = ocrd-cis-ocropy-recognize
-$(OCR1): PARAMS = "textequiv_level": "glyph", "model": "fraktur.pyrnn"
-$(OCR2): PARAMS = "textequiv_level": "glyph", "model": "fraktur-jze.pyrnn"
+$(OCR1): PARAMS = "textequiv_level": "glyph", "model": "fraktur.pyrnn.gz"
+$(OCR2): PARAMS = "textequiv_level": "glyph", "model": "fraktur-jze.pyrnn.gz"
 
 $(OCR3) $(OCR4) $(OCR5) $(OCR6) $(OCR7): TOOL = ocrd-tesserocr-recognize
 $(OCR3): PARAMS = "textequiv_level" : "glyph", "overwrite_words": true, "model" : "script/Fraktur"

--- a/gt-binarize-page-olena-sauvola-deskew-page-ocropy-clip-deskew-region-tesseract-resegment-dewarp-ocr-ocropy-tesseract.mk
+++ b/gt-binarize-page-olena-sauvola-deskew-page-ocropy-clip-deskew-region-tesseract-resegment-dewarp-ocr-ocropy-tesseract.mk
@@ -84,8 +84,8 @@ OCR8 = $(DEW:$(INPUT)-%=OCR-D-OCR-CALA-gt4histocr-%)
 $(OCR1) $(OCR2) $(OCR3) $(OCR4) $(OCR5) $(OCR6) $(OCR7) $(OCR8): $(DEW)
 
 $(OCR1) $(OCR2): TOOL = ocrd-cis-ocropy-recognize
-$(OCR1): PARAMS = "textequiv_level": "glyph", "model": "fraktur.pyrnn"
-$(OCR2): PARAMS = "textequiv_level": "glyph", "model": "fraktur-jze.pyrnn"
+$(OCR1): PARAMS = "textequiv_level": "glyph", "model": "fraktur.pyrnn.gz"
+$(OCR2): PARAMS = "textequiv_level": "glyph", "model": "fraktur-jze.pyrnn.gz"
 
 $(OCR3) $(OCR4) $(OCR5) $(OCR6) $(OCR7): TOOL = ocrd-tesserocr-recognize
 $(OCR3): PARAMS = "textequiv_level" : "glyph", "overwrite_words": true, "model" : "script/Fraktur"

--- a/gt-binarize-page-olena-sauvola-deskew-page-ocropy-clip-resegment-dewarp-ocr-ocropy-tesseract.mk
+++ b/gt-binarize-page-olena-sauvola-deskew-page-ocropy-clip-resegment-dewarp-ocr-ocropy-tesseract.mk
@@ -72,8 +72,8 @@ OCR8 = $(DEW:$(INPUT)-%=OCR-D-OCR-CALA-gt4histocr-%)
 $(OCR1) $(OCR2) $(OCR3) $(OCR4) $(OCR5) $(OCR6) $(OCR7) $(OCR8): $(DEW)
 
 $(OCR1) $(OCR2): TOOL = ocrd-cis-ocropy-recognize
-$(OCR1): PARAMS = "textequiv_level": "glyph", "model": "fraktur.pyrnn"
-$(OCR2): PARAMS = "textequiv_level": "glyph", "model": "fraktur-jze.pyrnn"
+$(OCR1): PARAMS = "textequiv_level": "glyph", "model": "fraktur.pyrnn.gz"
+$(OCR2): PARAMS = "textequiv_level": "glyph", "model": "fraktur-jze.pyrnn.gz"
 
 $(OCR3) $(OCR4) $(OCR5) $(OCR6) $(OCR7): TOOL = ocrd-tesserocr-recognize
 $(OCR3): PARAMS = "textequiv_level" : "glyph", "overwrite_words": true, "model" : "script/Fraktur"

--- a/gt-binarize-page-olena-wolf-denoise-ocropy-clip-resegment-dewarp-ocr-ocropy-tesseract.mk
+++ b/gt-binarize-page-olena-wolf-denoise-ocropy-clip-resegment-dewarp-ocr-ocropy-tesseract.mk
@@ -66,8 +66,8 @@ OCR8 = $(DEW:$(INPUT)-%=OCR-D-OCR-CALA-gt4histocr-%)
 $(OCR1) $(OCR2) $(OCR3) $(OCR4) $(OCR5) $(OCR6) $(OCR7) $(OCR8): $(DEW)
 
 $(OCR1) $(OCR2): TOOL = ocrd-cis-ocropy-recognize
-$(OCR1): PARAMS = "textequiv_level": "glyph", "model": "fraktur.pyrnn"
-$(OCR2): PARAMS = "textequiv_level": "glyph", "model": "fraktur-jze.pyrnn"
+$(OCR1): PARAMS = "textequiv_level": "glyph", "model": "fraktur.pyrnn.gz"
+$(OCR2): PARAMS = "textequiv_level": "glyph", "model": "fraktur-jze.pyrnn.gz"
 
 $(OCR3) $(OCR4) $(OCR5) $(OCR6) $(OCR7): TOOL = ocrd-tesserocr-recognize
 $(OCR3): PARAMS = "textequiv_level" : "glyph", "overwrite_words": true, "model" : "script/Fraktur"

--- a/gt-binarize-page-olena-wolf-denoise-ocropy-deskew-page-ocropy-clip-deskew-region-tesseract-resegment-dewarp-ocr-ocropy-tesseract.mk
+++ b/gt-binarize-page-olena-wolf-denoise-ocropy-deskew-page-ocropy-clip-deskew-region-tesseract-resegment-dewarp-ocr-ocropy-tesseract.mk
@@ -90,8 +90,8 @@ OCR8 = $(DEW:$(INPUT)-%=OCR-D-OCR-CALA-gt4histocr-%)
 $(OCR1) $(OCR2) $(OCR3) $(OCR4) $(OCR5) $(OCR6) $(OCR7) $(OCR8): $(DEW)
 
 $(OCR1) $(OCR2): TOOL = ocrd-cis-ocropy-recognize
-$(OCR1): PARAMS = "textequiv_level": "glyph", "model": "fraktur.pyrnn"
-$(OCR2): PARAMS = "textequiv_level": "glyph", "model": "fraktur-jze.pyrnn"
+$(OCR1): PARAMS = "textequiv_level": "glyph", "model": "fraktur.pyrnn.gz"
+$(OCR2): PARAMS = "textequiv_level": "glyph", "model": "fraktur-jze.pyrnn.gz"
 
 $(OCR3) $(OCR4) $(OCR5) $(OCR6) $(OCR7): TOOL = ocrd-tesserocr-recognize
 $(OCR3): PARAMS = "textequiv_level" : "glyph", "overwrite_words": true, "model" : "script/Fraktur"

--- a/gt-binarize-page-olena-wolf-denoise-ocropy-deskew-page-ocropy-clip-resegment-dewarp-ocr-ocropy-tesseract.mk
+++ b/gt-binarize-page-olena-wolf-denoise-ocropy-deskew-page-ocropy-clip-resegment-dewarp-ocr-ocropy-tesseract.mk
@@ -78,8 +78,8 @@ OCR8 = $(DEW:$(INPUT)-%=OCR-D-OCR-CALA-gt4histocr-%)
 $(OCR1) $(OCR2) $(OCR3) $(OCR4) $(OCR5) $(OCR6) $(OCR7) $(OCR8): $(DEW)
 
 $(OCR1) $(OCR2): TOOL = ocrd-cis-ocropy-recognize
-$(OCR1): PARAMS = "textequiv_level": "glyph", "model": "fraktur.pyrnn"
-$(OCR2): PARAMS = "textequiv_level": "glyph", "model": "fraktur-jze.pyrnn"
+$(OCR1): PARAMS = "textequiv_level": "glyph", "model": "fraktur.pyrnn.gz"
+$(OCR2): PARAMS = "textequiv_level": "glyph", "model": "fraktur-jze.pyrnn.gz"
 
 $(OCR3) $(OCR4) $(OCR5) $(OCR6) $(OCR7): TOOL = ocrd-tesserocr-recognize
 $(OCR3): PARAMS = "textequiv_level" : "glyph", "overwrite_words": true, "model" : "script/Fraktur"


### PR DESCRIPTION
Companion to https://github.com/cisocrgroup/ocrd_cis/pull/49

> pyrnn models are generally distributed gzipped. If loading gzipped models is inefficient, I can also adapt OCR-D/ocrd_all#103 to gunzip models after download.