### PR TITLE
Modifiy cp statement (fix build on MacOS)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ $(BINDIR) $(SHAREDIR):
 	@mkdir $@
 
 install: install-bin | $(SHAREDIR)
-	cp -Lf -t $(SHAREDIR) $(EXISTING_MAKEFILES) $(EXISTING_TRANSFORMS) ocrd-tool.json
+	cp -Lf $(EXISTING_MAKEFILES) $(EXISTING_TRANSFORMS) ocrd-tool.json $(SHAREDIR)
 	mv $(SHAREDIR)/workflow.mk  $(SHAREDIR)/Makefile
 
 uninstall:


### PR DESCRIPTION
The default cp on MacOS does not support -t, so builds fail there
when this option is used.

Signed-off-by: Stefan Weil <sw@weilnetz.de>