### PR TITLE
use mkdir -p when creating SHAREDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ $(XSLPROGS:%=$(BINDIR)/%): %: xsl-transform
 	chmod +x $@
 
 $(BINDIR) $(SHAREDIR):
-	@mkdir $@
+	@mkdir -p $@
 
 install: install-bin | $(SHAREDIR)
 	cp -Lf $(EXISTING_MAKEFILES) $(EXISTING_TRANSFORMS) ocrd-tool.json $(SHAREDIR)


### PR DESCRIPTION
Without `-p`, install into a fresh pyenv-created venv fails because `$VIRTUAL_ENV/share` does not exist.