### PR TITLE
Make dockerimage work again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM ocrd/core AS base
+ARG DOCKER_BASE_IMAGE
+FROM $DOCKER_BASE_IMAGE
 ARG VCS_REF
 ARG BUILD_DATE
 LABEL \
@@ -8,7 +9,7 @@ LABEL \
     org.label-schema.build-date=$BUILD_DATE
 
 SHELL ["/bin/bash", "-c"]
-WORKDIR /build
+WORKDIR /build/workflow-configuration
 
 COPY ocrd-tool.json .
 COPY ocrd-make ocrd-import ocrd-page-transform xsl-transform .
@@ -17,7 +18,7 @@ COPY *.xsl .
 COPY README.md .
 RUN make deps-ubuntu
 RUN make install VIRTUAL_ENV=/usr/local
-RUN rm -fr /build
+RUN rm -fr /build/workflow-configuration
 
 WORKDIR /data
 VOLUME ["/data"]

--- a/Makefile
+++ b/Makefile
@@ -106,12 +106,14 @@ test/data2:
 	ocrd workspace -d $@ rename-group ORIGINAL OCR-D-IMG
 	ocrd workspace -d $@ prune-files
 
-TAG ?= bertsky/workflow-configuration
+DOCKER_BASE_IMAGE = docker.io/ocrd/core-cuda-torch:v2.69.0
+DOCKER_TAG ?= bertsky/workflow-configuration
 docker:
 	docker build \
-	-t $(TAG) \
-	--build-arg VCS_REF=$(git rev-parse --short HEAD) \
-	--build-arg BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ") .
+	--build-arg DOCKER_BASE_IMAGE=$(DOCKER_BASE_IMAGE) \
+	--build-arg VCS_REF=$$(git rev-parse --short HEAD) \
+	--build-arg BUILD_DATE=$$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
+	-t $(DOCKER_TAG) .
 
 .PHONY: deps-ubuntu install install-bin uninstall test docker
 


### PR DESCRIPTION
The latest dockerimage is not working due to ocr-d core changes. This adds the "usual" changes, which you already made to the other processors.